### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dahln/Dahln.Stack/security/code-scanning/2](https://github.com/dahln/Dahln.Stack/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/pr-validation.yml`, immediately after the trigger section (`on:` block) and before `jobs:`.  
For this workflow, the minimal safe permission is:

- `contents: read`

This preserves existing functionality (checkout/build/test) while ensuring the token cannot write unless later explicitly expanded. No imports, methods, or dependency changes are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
