### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
   #   types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dahln/Dahln.Stack/security/code-scanning/1](https://github.com/dahln/Dahln.Stack/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or job) to enforce least privilege for `GITHUB_TOKEN`.

Best single fix here: in `.github/workflows/deploy.yml`, add a workflow-level permissions block directly under `on:` (before `jobs:`) with `contents: read`. This is sufficient for `actions/checkout@v4` and keeps token scope minimal for all jobs in this workflow unless overridden later.

No imports, methods, or dependency changes are required—just YAML configuration in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
