### PR TITLE
Potential fix for code scanning alert no. 3: Exposure of private information

### DIFF
--- a/Dahln.Stack.API/Utility/EmailSender.cs
+++ b/Dahln.Stack.API/Utility/EmailSender.cs
@@ -93,13 +93,13 @@ internal sealed class EmailSender : IEmailSender<IdentityUser>
     {
         if (string.IsNullOrWhiteSpace(email))
         {
-            return "[redacted]";
+            return "[Address is Null or Empty]";
         }
 
         var atIndex = email.IndexOf('@');
         if (atIndex <= 0 || atIndex == email.Length - 1)
         {
-            return "[redacted]";
+            return "[Address does not have a valid @]";
         }
 
         var localPart = email.Substring(0, atIndex);

--- a/Dahln.Stack.API/Utility/EmailSender.cs
+++ b/Dahln.Stack.API/Utility/EmailSender.cs
@@ -83,9 +83,29 @@ internal sealed class EmailSender : IEmailSender<IdentityUser>
         emailMessage.AddCustomHeader("List-Unsubscribe", $"<mailto:{fromEmail}?subject=Unsubscribe>");
 
         var response = await service.SendEmail(emailMessage);
+        var redactedToEmail = RedactEmailForLog(toEmail);
         _logger.LogInformation(response.Data?.Error == null
-                               ? $"Email to {toEmail} queued successfully!"
-                               : $"Failure Email to {toEmail}: {response.Data.Error}");
+                               ? $"Email to {redactedToEmail} queued successfully!"
+                               : $"Failure Email to {redactedToEmail}: {response.Data.Error}");
+    }
+
+    private static string RedactEmailForLog(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return "[redacted]";
+        }
+
+        var atIndex = email.IndexOf('@');
+        if (atIndex <= 0 || atIndex == email.Length - 1)
+        {
+            return "[redacted]";
+        }
+
+        var localPart = email.Substring(0, atIndex);
+        var domainPart = email.Substring(atIndex);
+        var visibleLocal = localPart.Length > 1 ? localPart.Substring(0, 1) : "*";
+        return $"{visibleLocal}***{domainPart}";
     }
 
     //This is the stock method.


### PR DESCRIPTION
Potential fix for [https://github.com/dahln/Dahln.Stack/security/code-scanning/3](https://github.com/dahln/Dahln.Stack/security/code-scanning/3)

To fix this without changing functionality, keep success/failure logging but stop writing raw recipient email addresses to logs. The best minimal fix is to log a redacted form of the email (or avoid it entirely). Redaction preserves troubleshooting value while avoiding direct exposure of private data.

**Change location:** `Dahln.Stack.API/Utility/EmailSender.cs`, inside `Execute(string apiKey, string fromEmail, string subject, string htmlMessage, string plainMessage, string toEmail)` where `_logger.LogInformation(...)` currently includes `{toEmail}`.

**Implementation approach:**
- Add a private helper method in `EmailSender` to redact email addresses (e.g., keep first char + domain, or fallback to `[redacted]`).
- Replace existing log statement to use redacted recipient instead of raw `toEmail`.
- Keep existing control flow and email sending behavior unchanged.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
