### PR TITLE
Potential fix for code scanning alert no. 5: Exposure of private information

### DIFF
--- a/Dahln.Stack.API/Utility/EmailSender.cs
+++ b/Dahln.Stack.API/Utility/EmailSender.cs
@@ -83,38 +83,14 @@ internal sealed class EmailSender : IEmailSender<IdentityUser>
         emailMessage.AddCustomHeader("List-Unsubscribe", $"<mailto:{fromEmail}?subject=Unsubscribe>");
 
         var response = await service.SendEmail(emailMessage);
-        var redactedToEmail = RedactEmailForLog(toEmail);
-        var logMessage = $"Failure Email to {redactedToEmail}: {response.Data?.Error}";
         if (response.Data?.Error == null)
         {
-            logMessage = $"Email to {redactedToEmail} queued successfully!";
+            _logger.LogInformation("Email queued successfully.");
         }
-
-        _logger.LogInformation(logMessage);
-    }
-
-    private static string RedactEmailForLog(string email)
-    {
-        if (string.IsNullOrWhiteSpace(email))
+        else
         {
-            return "[Address is Null or Empty]";
+            _logger.LogWarning("Email send failed: {ProviderError}", response.Data.Error);
         }
-
-        var atIndex = email.IndexOf('@');
-        if (atIndex <= 0 || atIndex == email.Length - 1)
-        {
-            return "[Address does not have a valid @]";
-        }
-
-        var localPart = email.Substring(0, atIndex);
-        var domainPart = email.Substring(atIndex);
-        var visibleLocal = "*";
-        if (localPart.Length > 1)
-        {
-            visibleLocal = localPart.Substring(0, 1);
-        }
-
-        return $"{visibleLocal}***{domainPart}";
     }
 
     //This is the stock method.


### PR DESCRIPTION
Potential fix for [https://github.com/dahln/Dahln.Stack/security/code-scanning/5](https://github.com/dahln/Dahln.Stack/security/code-scanning/5)

To fix this without changing functional behavior, stop writing any `toEmail`-derived value to logs. Keep success/failure logging, but make messages generic and avoid including recipient identifiers.

Best single fix in `Dahln.Stack.API/Utility/EmailSender.cs`:
- In `Execute(string apiKey, string fromEmail, string subject, string htmlMessage, string plainMessage, string toEmail)`, replace construction of `redactedToEmail`/`logMessage` with two direct log statements:
  - failure: log only provider error text (or a generic failure string),
  - success: log generic queued message.
- Remove `RedactEmailForLog` method since it is no longer needed and is the source of taint propagation.
- No import changes required.

This addresses all 17 variants because they all flow through the same logging path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
